### PR TITLE
should not normalize input of tanh

### DIFF
--- a/net.py
+++ b/net.py
@@ -99,7 +99,7 @@ class Generator(chainer.Chain):
             setattr(self, 'c' + str(n_resblock + 5),
                     CBR(64, 32, norm=norm, sample='up'))
             setattr(self, 'c' + str(n_resblock + 6),
-                    CBR(32, 3, norm=norm, sample='none-7', activation=F.tanh))
+                    CBR(32, 3, norm=None, sample='none-7', activation=F.tanh))
 
     def __call__(self, x):
         h = self.c1(x)


### PR DESCRIPTION
I think that input of tanh should not be normalized, because it restricts output color distribution to normal distribution.

Actually, original implementation does not have normalization layer before tanh layer.
https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/blob/079da5c02fd99ef35d7cad0e20c2924b7c2bcffd/models/networks.py#L246-L247